### PR TITLE
Removed import of expired signing key for apt-based installs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Lacework, Inc.
+Copyright (c) 2022 Lacework, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,14 +12,7 @@
 
 - name: add the lacework key (apt)
   apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: "18E76630"
-    state: present
-  when: ansible_pkg_mgr == 'apt'
-
-- name: add the lacework key (apt)
-  apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    keyserver: hkp://keyserver.ubuntu.com
     id: "EE0CC692"
     state: present
   when: ansible_pkg_mgr == 'apt'


### PR DESCRIPTION
Removed the apt-key import of an expired Lacework signing key.  This should resolve #2 