### PR TITLE
fix: migrated to `include_tasks` from deprecated `include`

### DIFF
--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -260,7 +260,7 @@
 
         - name: Wait for IP assignment to finish
           pause:
-            seconds: 20
+            seconds: 60
 
         - name: Collect instance configs
           set_fact:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ platforms:
     image_owner: "309956199498"
     image_name: RHEL-8*HVM*-x86_64-*
     instance_type: t3.micro
+    region: ${AWS_REGION}
     vpc_subnet_id: ${AWS_SUBNET_ID}
     tags:
       Name: molecule_rhel_instance_amd64
@@ -15,6 +16,7 @@ platforms:
     image_owner: "309956199498"
     image_name: RHEL-8*HVM*-arm64-*
     instance_type: t4g.micro
+    region: ${AWS_REGION}
     vpc_subnet_id: ${AWS_SUBNET_ID}
     tags:
       Name: molecule_rhel_instance_arm64
@@ -22,6 +24,7 @@ platforms:
     image_owner: "099720109477"
     image_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
     instance_type: t3.micro
+    region: ${AWS_REGION}
     vpc_subnet_id: ${AWS_SUBNET_ID}
     tags:
       Name: molecule_ubuntu_instance_amd64
@@ -29,6 +32,7 @@ platforms:
     image_owner: "099720109477"
     image_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*
     instance_type: t4g.micro
+    region: ${AWS_REGION}
     vpc_subnet_id: ${AWS_SUBNET_ID}
     tags:
       Name: molecule_ubuntu_instance_arm64

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,8 @@
     msg: "{{ ansible_pkg_mgr }}"
     verbosity: 3
 
-- include: install.yml
+- include_tasks: install.yml
   when: lacework_state == "present"
 
-- include: uninstall.yml
+- include_tasks: uninstall.yml
   when: lacework_state == "absent"


### PR DESCRIPTION
This PR is meant to address #10 by migrating off of `include` in [tasks/main.yml](https://github.com/alannix-lw/lacework-agent-ansible-role/blob/main/tasks/main.yml) to the newer `include_tasks` builtin.